### PR TITLE
fix reorg handling with hot blocks, plus ci and small devops fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: ci
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+
+      - name: install dependencies
+        run: npm ci
+
+      - name: compile typescript
+        run: npm run build

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,8 @@ services:
     volumes:
       - ./data/db:/var/lib/postgresql
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      # Must match POSTGRES_USER / POSTGRES_DB (not hardcoded postgres) when .env overrides DB_USER
+      test: ["CMD-SHELL", "pg_isready -U \"$$POSTGRES_USER\" -d \"$$POSTGRES_DB\""]
       interval: 3s
       timeout: 3s
       retries: 30

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "node": ">=16"
   },
   "scripts": {
-    "build": "rm -rf lib && tsc"
+    "build": "npx --yes rimraf lib && tsc"
   },
   "dependencies": {
     "@subsquid/graphql-server": "^4.6.0",

--- a/src/main.ts
+++ b/src/main.ts
@@ -20,10 +20,11 @@ processor.run(new TypeormDatabase({supportHotBlocks: true}), async (ctx) => {
     let extrinsics: Extrinsic[] = createExtrinsics(blockExtrinsics)
 
     await ctx.store.upsert([...accounts.values()])
-    await ctx.store.insert(transfers)
-    await ctx.store.insert(claimCreations)
-    await ctx.store.insert(claims)
-    await ctx.store.insert(extrinsics)
+    // hot blocks can replay the same ids after a reorg — upsert avoids duplicate key failures from insert()
+    await ctx.store.upsert(transfers)
+    await ctx.store.upsert(claimCreations)
+    await ctx.store.upsert(claims)
+    await ctx.store.upsert(extrinsics)
 })
 
 interface TransferEvent {


### PR DESCRIPTION
## what changed

- **processor writes**: `TypeormDatabase` runs with `supportHotBlocks: true`, so the same substrate event ids can be processed again after a chain reorg. Using `insert()` for transfers, claims, claim creations, and extrinsics can hit **duplicate key** errors or leave bad rows; these are now **`upsert()`** so replays stay idempotent on the primary key (`id`).

- **`npm run build`**: Replaced `rm -rf` with `npx rimraf` so the build works on Windows and matches the pattern already used in `commands.json`.

- **docker compose**: The Postgres healthcheck used `-U postgres` while `POSTGRES_USER` comes from `DB_USER`. If someone changes the user in `.env`, the db never becomes healthy. The check now uses `POSTGRES_USER` / `POSTGRES_DB` inside the container.

- **CI**: Added a workflow that runs `npm ci` and `npm run build` on pushes and PRs to `main`, so TypeScript breaks are caught before merge (the existing workflow only runs when `Containerfile` changes).

---

made by mooncitydev